### PR TITLE
Profile: instead of Logical:

### DIFF
--- a/input/fsh/obligations/currentPregnancy-obl.fsh
+++ b/input/fsh/obligations/currentPregnancy-obl.fsh
@@ -1,4 +1,4 @@
-Logical: EHDSCurrentPregnancyObligations
+Profile: EHDSCurrentPregnancyObligations
 Parent: EHDSCurrentPregnancy
 Title: "Current pregnancy obligations"
 Description: "Obligations for the logical model for current pregnancy."

--- a/input/fsh/obligations/dispense-obl.fsh
+++ b/input/fsh/obligations/dispense-obl.fsh
@@ -1,4 +1,4 @@
-Logical: EHDSMedicationDispenseObligations
+Profile: EHDSMedicationDispenseObligations
 Parent: EHDSMedicationDispense
 Title: "Medication dispense model obligations"
 Description: "Obligations for the logical model for medication dispense for dispensing/pharmacy systems (producer) and prescribing systems or prescription repositories(consumer)."

--- a/input/fsh/obligations/patient-summary-obl.fsh
+++ b/input/fsh/obligations/patient-summary-obl.fsh
@@ -1,4 +1,4 @@
-Logical: EHDSPatientSummaryObligations
+Profile: EHDSPatientSummaryObligations
 Parent: EHDSPatientSummary
 Title: "Patient summary obligations"
 Description: "Obligations for the logical model for patient summary."

--- a/input/fsh/obligations/prescription-obl.fsh
+++ b/input/fsh/obligations/prescription-obl.fsh
@@ -1,5 +1,5 @@
 // EHDS<System><Model>Obligations
-Logical: EHDSMedicationPrescriptionObligations
+Profile: EHDSMedicationPrescriptionObligations
 Parent: EHDSMedicationPrescription
 Title: "Medication prescription model obligations"
 Description: "Obligations for the logical model for medication prescription body for prescribing systems (producer) and dispensing systems (consumer)."


### PR DESCRIPTION
Inconsistency of use of Logical: vs Profile: in obligation models. Made it consistent using least amount of changes.